### PR TITLE
iOS 11+ free space calculation update

### DIFF
--- a/iOS/DiskUtils.mm
+++ b/iOS/DiskUtils.mm
@@ -1,19 +1,31 @@
 extern "C"
 {
-    uint64_t getAvailableDiskSpace (){
+    uint64_t getAvailableDiskSpace () {
         uint64_t totalFreeSpace = 0;
-        NSError *error = nil;
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-        NSDictionary *dictionary = [[NSFileManager defaultManager] attributesOfFileSystemForPath:[paths lastObject] error: &error];
-        
-        if (dictionary) {
-            NSNumber *fileSystemSizeInBytes = [dictionary objectForKey: NSFileSystemSize];
-            NSNumber *freeFileSystemSizeInBytes = [dictionary objectForKey:NSFileSystemFreeSize];
-            totalFreeSpace = [freeFileSystemSizeInBytes unsignedLongLongValue];
+        if (@available(iOS 11.0, *)) {
+            NSURL *fileURL = [[NSURL alloc] initFileURLWithPath:NSHomeDirectory()];
+            NSError *error = nil;
+            NSDictionary *results = [fileURL resourceValuesForKeys:@[NSURLVolumeAvailableCapacityForImportantUsageKey] error:&error];
+            if (!results) {
+                NSLog(@"Error Obtaining System Memory Info: Domain = %@, Code = %ld", [error domain], (long)[error code]);
+            } else {
+                NSLog(@"Available capacity for important usage: %@", results[NSURLVolumeAvailableCapacityForImportantUsageKey]);
+                totalFreeSpace = ((NSString *)results[NSURLVolumeAvailableCapacityForImportantUsageKey]).longLongValue;
+            }
         } else {
-            NSLog(@"Error Obtaining System Memory Info: Domain = %@, Code = %ld", [error domain], (long)[error code]);
+            NSError *error = nil;
+            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+            NSDictionary *dictionary = [[NSFileManager defaultManager] attributesOfFileSystemForPath:[paths lastObject] error: &error];
+            
+            if (dictionary) {
+                NSNumber *fileSystemSizeInBytes = [dictionary objectForKey: NSFileSystemSize];
+                NSNumber *freeFileSystemSizeInBytes = [dictionary objectForKey:NSFileSystemFreeSize];
+                totalFreeSpace = [freeFileSystemSizeInBytes unsignedLongLongValue];
+            } else {
+                NSLog(@"Error Obtaining System Memory Info: Domain = %@, Code = %ld", [error domain], (long)[error code]);
+            }
+            
         }
-        
         return (uint64_t)(totalFreeSpace/1024ll)/1024ll;
     }
     


### PR DESCRIPTION
iOS 11+ allows you to query free space for important usage or for opportunistic usage. Most app want to know the free space they could *possibly* use, not just the free space they use without bumping another app's cache. If we want to extend the API to support opportunistic free space checking that would be more involved.